### PR TITLE
Add GitHub action to build and publish package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish package
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        run: uvx twine upload dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,17 +10,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          version: "0.4.15"
+          enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install uv
+          python-version-file: .python-version
 
       - name: Build package
         run: uv build
@@ -30,3 +31,6 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: uvx twine upload dist/*
+
+      - name: Cleanup
+        run: uv cache prune --ci

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Limalight
+
+![GitHub Actions Status](https://github.com/chekos/limalight/actions/workflows/publish.yml/badge.svg)
+
+A flexible display library for the Limonada Journaling Project, supporting both OLED hardware and terminal output.


### PR DESCRIPTION
Add GitHub action to publish package to PyPI

* **GitHub Action**: Create a new GitHub action file `publish.yml` under `.github/workflows/`
  - Add a job to install `uv`
  - Add a job to build the package using `uv build`
  - Add a job to publish to PyPI using `uvx twine upload dist/*`
  - Use the environmental variables `$TWINE_USERNAME` and `$TWINE_PASSWORD`
  - Trigger the action only when a new release is published

* **README.md**: Add a badge for the GitHub action status at the top of the file

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chekos/limalight?shareId=4e798855-eceb-4ec4-a8e9-0225ef48ee56).